### PR TITLE
Fixed remote files not found error

### DIFF
--- a/win-install.cmd
+++ b/win-install.cmd
@@ -48,7 +48,7 @@ unlocker.exe
 
 echo.
 echo Getting VMware Tools...
-gettools.exe
+python.exe gettools.py
 xcopy /F /Y .\tools\darwin*.* "%InstallPath%"
 
 echo.


### PR DESCRIPTION
As the latest published files on vmware server do not ship darwin tools, this patch allows to fall back to the latest version that has them