### PR TITLE
fix path to python executable

### DIFF
--- a/win-install.cmd
+++ b/win-install.cmd
@@ -44,11 +44,11 @@ xcopy /F /Y "%InstallPath%vmwarebase.dll" .\backup\
 
 echo.
 echo Patching...
-python unlocker.py
+.\python\python.exe unlocker.py
 
 echo.
 echo Getting VMware Tools...
-python gettools.py
+.\python\python.exe gettools.py
 xcopy /F /Y .\tools\darwin*.* "%InstallPath%"
 
 echo.

--- a/win-test-install.cmd
+++ b/win-test-install.cmd
@@ -44,11 +44,11 @@ xcopy /F /Y "%InstallPath%vmwarebase.dll" .\backup\
 
 echo.
 echo Patching...
-python unlocker.py
+.\python\python.exe unlocker.py
 
 echo.
 echo Getting VMware Tools...
-python gettools.py
+.\python\python.exe gettools.py
 xcopy /F /Y .\tools\darwin*.* "%InstallPath%"
 
 echo.

--- a/win-update-tools.cmd
+++ b/win-update-tools.cmd
@@ -18,7 +18,7 @@ for /F "tokens=2* delims=	 " %%A in ('REG QUERY %KeyName% /v InstallPath') do se
 echo VMware is installed at: %InstallPath%
 
 echo Getting VMware Tools...
-python gettools.py
+.\python\python.exe gettools.py
 xcopy /F /Y .\tools\darwin*.* "%InstallPath%"
 
 popd


### PR DESCRIPTION
Fixes the following error when executing one of the windows scripts : 
```
Getting VMware Tools...
'python' is not recognized as an internal or external command,
operable program or batch file.
File not found - darwin*.*
0 File(s) copied
```